### PR TITLE
Fix typing of SyncValue.

### DIFF
--- a/packages/bridge/src/model/index.ts
+++ b/packages/bridge/src/model/index.ts
@@ -1,7 +1,7 @@
 import Automerge from 'automerge'
 import { Node, Range } from 'slate'
 
-export type SyncValue = Automerge.List<Node[]>
+export type SyncValue = Automerge.List<Node>
 
 export type SyncDoc = Automerge.Doc<{ children: SyncValue; cursors: Cursors }>
 


### PR DESCRIPTION
Internally, this is an uncaught type error because of `any` typing at [iterate](https://github.com/cudr/slate-collaborative/blob/master/packages/bridge/src/path/index.ts#L8).

Externally, this forces us to cast our `Node[]` typings as `any`.