### PR TITLE
Missing query argument in nspMiddleware

### DIFF
--- a/packages/backend/src/SocketIOConnection.ts
+++ b/packages/backend/src/SocketIOConnection.ts
@@ -67,7 +67,7 @@ export default class SocketIOCollaboration {
 
     if (!this.backend.getDocument(path)) {
       const doc = onDocumentLoad
-        ? await onDocumentLoad(path)
+        ? await onDocumentLoad(path, query)
         : this.options.defaultValue
 
       if (!doc) return next(null, false)


### PR DESCRIPTION
Without this argument it's not possible to use query object with token and other items.