### PR TITLE
Fix destory

### DIFF
--- a/packages/client/src/automerge-editor.ts
+++ b/packages/client/src/automerge-editor.ts
@@ -149,6 +149,10 @@ export const AutomergeEditor = {
   garbageCursor: (e: AutomergeEditor, docId: string) => {
     const doc = e.docSet.getDoc(docId)
 
+    if (!doc) {
+      return
+    }
+
     const changed = Automerge.change<SyncDoc>(doc, (d: any) => {
       delete d.cusors
     })

--- a/packages/client/src/withSocketIO.ts
+++ b/packages/client/src/withSocketIO.ts
@@ -122,6 +122,8 @@ const withSocketIO = <T extends AutomergeEditor>(
    */
 
   e.destroy = () => {
+    e.socket.removeListener('disconnect')
+
     e.socket.close()
 
     e.closeConnection()


### PR DESCRIPTION
Since we are destroying, we do not want the disconnect handler be called then crash.