### PR TITLE
Fix setNodes undefined value since automerge does not handle undefined value correctly.

### DIFF
--- a/packages/bridge/src/apply/node/setNode.ts
+++ b/packages/bridge/src/apply/node/setNode.ts
@@ -9,7 +9,12 @@ const setNode = (doc: SyncValue, op: SetNodeOperation): SyncValue => {
   const { newProperties } = op
 
   for (let key in newProperties) {
-    node[key] = newProperties[key]
+    const value = newProperties[key]
+    if (value !== undefined) {
+      node[key] = value
+    } else {
+      delete node[key]
+    }
   }
 
   return doc


### PR DESCRIPTION
when we handle some todo (checked) item, undo will try to set value of undefined back to node, which is not correctly supported in automerge, https://github.com/automerge/automerge/commit/2a180637b5389166b12e994cced7b73e1d695201#r45810448

So, to prevent from error, we instead delete the property in this case.