### PR TITLE
Call normalize after load document.

### DIFF
--- a/packages/client/src/automerge-editor.ts
+++ b/packages/client/src/automerge-editor.ts
@@ -100,9 +100,10 @@ export const AutomergeEditor = {
 
     Editor.withoutNormalizing(e, () => {
       e.children = toJS(mergedDoc).children
-
-      e.onChange()
     })
+
+    // onChange expect valid doc, we make sure do normalization before that.
+    e.onChange()
   },
 
   /**

--- a/packages/client/src/automerge-editor.ts
+++ b/packages/client/src/automerge-editor.ts
@@ -103,6 +103,7 @@ export const AutomergeEditor = {
     })
 
     // onChange expect valid doc, we make sure do normalization before that.
+    Editor.normalize(e, { force: true })
     e.onChange()
   },
 

--- a/packages/client/src/automerge-editor.ts
+++ b/packages/client/src/automerge-editor.ts
@@ -99,7 +99,9 @@ export const AutomergeEditor = {
     e.docSet.setDoc(docId, mergedDoc)
 
     Editor.withoutNormalizing(e, () => {
-      e.children = toJS(mergedDoc).children
+      const doc = toJS(mergedDoc)
+      e.children = doc.children
+      e.onCursor && e.onCursor(doc.cursors)
     })
 
     // onChange expect valid doc, we make sure do normalization before that.


### PR DESCRIPTION
Sometimes a doc is just broken and need fix. current load document code does not call normalization after load doc. This PR add a force normalization after code load, then call the onChange to prevent from some crash due to invalid doc structure.

But, I am not sure whether this is a common good implement since it fix the doc structure without warning or logging, client code has no chance to involve this. on the other hand, without this change, it probably just crash due to the onChange call finally do some batch before render work in Slate.

So, this is just the my current workaround for broken doc, maybe not a perfect PR for general cases.