### PR TITLE
Do not do shortcut merge batch operations, do it one by one for toSlateOp

### DIFF
--- a/packages/bridge/src/convert/index.ts
+++ b/packages/bridge/src/convert/index.ts
@@ -19,10 +19,12 @@ const byAction = {
 const rootKey = '00000000-0000-0000-0000-000000000000'
 
 const toSlateOp = (ops: Automerge.Diff[], doc: SyncDoc) => {
+  const tempDoc = toJS(doc)
+
   const iterate = (acc: [any, any[]], op: Automerge.Diff): any => {
     const action = byAction[op.action]
 
-    const result = action ? action(op, acc, doc) : acc
+    const result = action ? action(op, acc, doc, tempDoc) : acc
 
     return result
   }
@@ -34,9 +36,7 @@ const toSlateOp = (ops: Automerge.Diff[], doc: SyncDoc) => {
     []
   ])
 
-  const tempDoc = toJS(doc)
-
-  return defer.flatMap(op => op(tempTree, tempDoc)).filter(op => op)
+  return defer.flatMap(op => op).filter(op => op)
 }
 
 export { toSlateOp }

--- a/packages/bridge/src/convert/remove.ts
+++ b/packages/bridge/src/convert/remove.ts
@@ -90,7 +90,9 @@ const opRemove = (
 
     if (type === 'map' && path) {
       // remove a key from map, mapping to slate set a key's value to undefined.
-      ops.push(setDataOp(op, doc)(map, tmpDoc))
+      if (path[0] === 'children') {
+        ops.push(setDataOp(op, doc)(map, tmpDoc))
+      }
       return [map, ops]
     }
 
@@ -108,8 +110,6 @@ const opRemove = (
     if (!path) return [map, ops]
 
     const key = path[path.length - 1]
-
-    if (key === 'cursors' || op.key === 'cursors') return [map, ops]
 
     const fn = key === 'text' ? removeTextOp : removeNodeOp
 

--- a/packages/bridge/src/convert/remove.ts
+++ b/packages/bridge/src/convert/remove.ts
@@ -3,6 +3,7 @@ import { Element } from 'slate'
 
 import { toSlatePath, toJS } from '../utils'
 import { getTarget } from '../path'
+import { setDataOp } from './set'
 
 const removeTextOp = (op: Automerge.Diff) => (map: any, doc: Element) => {
   try {
@@ -86,6 +87,12 @@ const opRemove = (
 ) => {
   try {
     const { index, path, obj, type } = op
+
+    if (type === 'map' && path) {
+      // remove a key from map, mapping to slate set a key's value to undefined.
+      ops.push(setDataOp(op, doc)(map, tmpDoc))
+      return [map, ops]
+    }
 
     if (
       map.hasOwnProperty(obj) &&

--- a/packages/bridge/src/convert/remove.ts
+++ b/packages/bridge/src/convert/remove.ts
@@ -55,18 +55,16 @@ const removeNodeOp = (op: Automerge.Diff) => (map: any, doc: Element) => {
       throw new TypeError('Target is not found!')
     }
 
-    if (!map.hasOwnProperty(obj)) {
-      map[obj] = target
-    }
-
     if (!Number.isInteger(index)) {
       throw new TypeError('Index is not a number')
     }
 
     if (parent?.children?.[index as number]) {
       parent.children.splice(index, 1)
+      map[obj] = parent?.children
     } else if (parent?.[index as number]) {
       parent.splice(index, 1)
+      map[obj] = parent
     }
 
     return {

--- a/packages/bridge/src/convert/set.ts
+++ b/packages/bridge/src/convert/set.ts
@@ -1,29 +1,33 @@
 import * as Automerge from 'automerge'
+import { Element, Node } from 'slate'
 
 import { toSlatePath, toJS } from '../utils'
 
 const setDataOp = (
   { key = '', obj, path, value }: Automerge.Diff,
   doc: any
-) => (map: any) => {
+) => (map: any, tmpDoc: Element) => {
+  const slatePath = toSlatePath(path)
+  const node = Node.get(tmpDoc, slatePath)
+  node[key] = toJS(map?.[value] || value)
   return {
     type: 'set_node',
-    path: toSlatePath(path),
+    path: slatePath,
     properties: {
       [key]: toJS(Automerge.getObjectById(doc, obj)?.[key])
     },
     newProperties: {
-      [key]: map?.[value] || value
+      [key]: toJS(node[key])
     }
   }
 }
 
-const opSet = (op: Automerge.Diff, [map, ops]: any, doc: any) => {
+const opSet = (op: Automerge.Diff, [map, ops]: any, doc: any, tmpDoc: any) => {
   const { link, value, path, obj, key } = op
 
   try {
     if (path && path.length && path[0] !== 'cursors') {
-      ops.push(setDataOp(op, doc))
+      ops.push(setDataOp(op, doc)(map, tmpDoc))
     } else if (map[obj]) {
       map[obj][key as any] = link ? map[value] : value
     }

--- a/packages/bridge/src/convert/set.ts
+++ b/packages/bridge/src/convert/set.ts
@@ -3,7 +3,7 @@ import { Element, Node } from 'slate'
 
 import { toSlatePath, toJS } from '../utils'
 
-const setDataOp = (
+export const setDataOp = (
   { key = '', obj, path, value }: Automerge.Diff,
   doc: any
 ) => (map: any, tmpDoc: Element) => {

--- a/packages/bridge/src/utils/index.ts
+++ b/packages/bridge/src/utils/index.ts
@@ -6,6 +6,9 @@ import { CollabAction } from '../model'
 export * from './testUtils'
 
 const toJS = (node: any) => {
+  if (node === undefined) {
+    return undefined
+  }
   try {
     return JSON.parse(JSON.stringify(node))
   } catch (e) {


### PR DESCRIPTION
Just a fast fix for merge_node like operations. since currently, the map are collected in the first round run, then the 2nd round run to generate slate ops. but, during that, the path could change due to remove or insert node. In some complex data structure cases, it will cause error, mainly can not find slate path.
So now this quick do it one by one, step by step, with the current step map and temp doc tree. no shortcut, just do it one by one.
The code is not fully tested, but it passed two merge_node crash cases in my usage. will keep this up to date if there will be any fix follow up.