### PR TITLE
Fix wrong isRemote false caused by the incorrect promise schedule case.

### DIFF
--- a/packages/client/src/automerge-editor.ts
+++ b/packages/client/src/automerge-editor.ts
@@ -141,7 +141,12 @@ export const AutomergeEditor = {
           e.onCursor && e.onCursor(updated.cursors)
         })
 
-        Promise.resolve().then(_ => (e.isRemote = false))
+        if (slateOps.length > 0) {
+          // XXX: only schedule set isRemote false when we did scheduled onChange by apply.
+          Promise.resolve().then(_ => (e.isRemote = false))
+        } else {
+          e.isRemote = false
+        }
       }
     } catch (e) {
       console.error(e)

--- a/packages/client/src/automerge-editor.ts
+++ b/packages/client/src/automerge-editor.ts
@@ -125,6 +125,8 @@ export const AutomergeEditor = {
       if (operations.length) {
         const slateOps = toSlateOp(operations, current)
 
+        // do not change isRemote flag for no-op case.
+        const wasRemote = e.isRemote
         e.isRemote = true
 
         Editor.withoutNormalizing(e, () => {
@@ -145,7 +147,7 @@ export const AutomergeEditor = {
           // XXX: only schedule set isRemote false when we did scheduled onChange by apply.
           Promise.resolve().then(_ => (e.isRemote = false))
         } else {
-          e.isRemote = false
+          e.isRemote = wasRemote
         }
       }
     } catch (e) {


### PR DESCRIPTION
The isRemote false promise should only be scheduled when any apply (slate schedule onChange in first apply) really happened.
Else, currently, is we got two remote applyOperation calls one by one, the first empty slate op one will schedule isRemote false, then the 2nd applyOperation will schedule onChange, and another isRemote false. which finally will cause the onChange runs with e.isRemote === false, and which will cause the remote caused slate ops be applied as local slate op again, and it will cause error.
This PR make sure only schedule isRemote = false when there is any onChange is scheduled, then it runs just after it to clear the isRemote flag.