### PR TITLE
setNode as slate does.

### DIFF
--- a/packages/bridge/src/apply/node/setNode.ts
+++ b/packages/bridge/src/apply/node/setNode.ts
@@ -10,7 +10,7 @@ const setNode = (doc: SyncValue, op: SetNodeOperation): SyncValue => {
 
   for (let key in newProperties) {
     const value = newProperties[key]
-    if (value !== undefined) {
+    if (value != null) {
       node[key] = value
     } else {
       delete node[key]


### PR DESCRIPTION
currently, slate-collaborative will save the null value to the data structure, but indeed, slate does not, they trade the null value as unset property, this PR align this behaviour so we won't get null value property after sync.